### PR TITLE
Time/DE: Don't parse "so"

### DIFF
--- a/Duckling/Time/DE/Corpus.hs
+++ b/Duckling/Time/DE/Corpus.hs
@@ -35,6 +35,7 @@ negativeCorpus = (context, testOptions, examples)
       [ "ein Hotel"
       , "ein Angebot"
       , "nächsten 5"
+      , "so"
       ]
 
 allExamples :: [Example]

--- a/Duckling/Time/DE/Rules.hs
+++ b/Duckling/Time/DE/Rules.hs
@@ -55,7 +55,7 @@ ruleDaysOfWeek = mkRuleDaysOfWeek
   , ( "Donnerstag", "donn?erstag|do\\.?"           )
   , ( "Freitag"   , "freitags?|fr\\.?"             )
   , ( "Samstag"   , "samstags?|sonnabends?|sa\\.?" )
-  , ( "Sonntag"   , "sonntags?|so\\.?"             )
+  , ( "Sonntag"   , "sonntags?|so\\."             )
   ]
 
 ruleMonths :: [Rule]


### PR DESCRIPTION
Summary:
"so" is an adverb in German: https://github.com/wit-ai/wit/issues/1860
It's also a short form for "Sonntag" (Sunday); making the dot mandatory.

Reviewed By: haoxuany

Differential Revision: D22900791

fbshipit-source-id: 8dc873f79a21ca2add074f9c664e84fae56f1e67